### PR TITLE
small update: 改行箇所の置換処理について

### DIFF
--- a/app.sh
+++ b/app.sh
@@ -3,5 +3,5 @@ from=en
 to=ja  # de, fr, es, etc.
 browser=xdg-open
 
-text=$(xclip c -o | sed ':loop; N; $!b loop; s/\n//g' | nkf -WwMQ | sed 's/=$//g' | tr = % | tr -d '\n')
+text=$(xclip c -o | sed ':loop; N; $!b loop; s/-\n//g' | sed ':loop; N; $!b loop; s/\n/ /g' | nkf -WwMQ | sed 's/=$//g' | tr = % | tr -d '\n')
 $browser "https://www.deepl.com/translator#${from}/${to}/${text}"


### PR DESCRIPTION
改行の置換処理を一部修正・追加しました。
これによってpdf文書などのコピーで発生する、不要な改行を正しく削除可能です。

例えば、"Red Apple"という文字列中に改行を含む場合を考えます。
このとき、現在の処理では以下のように動作します。
1) "Red\nApple" -> "RedApple"
2) "Red App-\nle" -> "Red App-le"

ハイフンを含む改行の場合は単純に削除し、それ以外の改行はスペースに置換をおこなうことで、どちらもただしく"Red Apple"となります。この処理を追加しました。

ご確認お願いします。