### PR TITLE
small update: /と|の置換処理について

### DIFF
--- a/deepl-clip.sh
+++ b/deepl-clip.sh
@@ -3,5 +3,5 @@ from=en
 to=ja  # de, fr, es, etc.
 browser=xdg-open
 
-text=$(xclip c -o | sed ':loop; N; $!b loop; s/\n//g' | nkf -WwMQ | sed 's/=$//g' | tr = % | tr -d '\n')
+text=$(xclip c -o | sed ':loop; N; $!b loop; s/\//\\\//g' | sed ':loop; N; $!b loop; s/|/\\|/g' | sed ':loop; N; $!b loop; s/\n//g' | nkf -WwMQ | sed 's/=$//g' | tr = % | tr -d '\n')
 $browser "https://www.deepl.com/translator#${from}/${to}/${text}"

--- a/deepl-clip.sh
+++ b/deepl-clip.sh
@@ -3,5 +3,5 @@ from=en
 to=ja  # de, fr, es, etc.
 browser=xdg-open
 
-text=$(xclip c -o | sed ':loop; N; $!b loop; s/\//\\\//g' | sed ':loop; N; $!b loop; s/|/\\|/g' | sed ':loop; N; $!b loop; s/\n//g' | nkf -WwMQ | sed 's/=$//g' | tr = % | tr -d '\n')
+text=$(xclip c -o | sed 's/\//\\\//g' | sed 's/|/\\|/g' | sed ':loop; N; $!b loop; s/\n//g' | nkf -WwMQ | sed 's/=$//g' | tr = % | tr -d '\n')
 $browser "https://www.deepl.com/translator#${from}/${to}/${text}"


### PR DESCRIPTION
文字列中に "/" や "|" が含まれる際の置換挙動を修正しました．

現状文字列中に "/" や "|" が含まれる場合，その文字以降が認識されません．
例えば現状の処理では以下のように動作します．
1. "I have a dog/cat." -> "T have a dog"
2. "The PDF is p(x|y)." -> "The PDF is p(x"（また翻訳後の欄に "y)." が入力される）

入力文字列中に "/" や "|" が含まれる場合，以下の様にエスケープシーケンスに変換されるようにしました．
1. "/" -> "\\/"
2. "|" -> "\\|"

ご確認お願いいたします．